### PR TITLE
Lib workaround for S10+, plus prevent null $ACTIVITY from causing disaster.

### DIFF
--- a/common/unity_install.sh
+++ b/common/unity_install.sh
@@ -50,7 +50,7 @@ esac
 IFS=$OIFS
 
 # Check for devices that need lib workaround
-if device_check "walleye" || device_check "taimen" || device_check "crosshatch" || device_check "blueline" || device_check "mata" || device_check "jasmine" || device_check "star2lte" || device_check "z2_row"; then
+if device_check "walleye" || device_check "taimen" || device_check "crosshatch" || device_check "blueline" || device_check "mata" || device_check "jasmine" || device_check "star2lte" || device_check "z2_row" || device_check "beyond2lte"; then
   LIBWA=true
 fi
 

--- a/common/unity_install.sh
+++ b/common/unity_install.sh
@@ -183,6 +183,9 @@ else
   LIBPATCH="\/system"; LIBDIR=/system; DYNAMICLIB=false
 fi
 
+# Sanity-check to avoid rm -rf /data/data disaster in v4afx.sh.
+[ -n "ACTIVITY" ] || exit 1
+
 sed -i "s/<SOURCE>/$SOURCE/g" $TMPDIR/common/sepolicy.sh
 sed -i -e "s/<ACTIVITY>/$ACTIVITY/g" -e "s|<FACTIVITY>|$FACTIVITY|g" $TMPDIR/common/service.sh
 sed -i "s/<ACTIVITY>/$ACTIVITY/g" $TMPDIR/common/v4afx.sh


### PR DESCRIPTION
The S10+ needs the lib workaround or will not work. Tested on my own device. No doubt the S10e and S10 need the same.

Also, a friend of mine installed Viper a few days ago and had his internal memory wiped. Study of the code reveals a great danger in `v4afx.sh` if `$ACTIVITY` is null when sed conducts in-place edits in `unity_install.sh`.

The `if/then` block that sets `$ACTIVITY` has an `else` clause that sets a default, but if the whole block fails for any reason, `$ACTIVITY` will be left unset.